### PR TITLE
Fix an async problem by running compile inside the getTemplates callback

### DIFF
--- a/tasks/aglio.js
+++ b/tasks/aglio.js
@@ -7,7 +7,7 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('aglio', 'Grunt plugin to generate aglio documentation', function() {
     var done = this.async();
     // Merge task-specific and/or target-specific options with these defaults.
-    
+
     var default_options = {
       seperator: "",
       theme: "default",
@@ -15,14 +15,15 @@ module.exports = function(grunt) {
         return src;
       }
     };
-    
+
     var options = _.extend(default_options, this.data);
-    
+    var files = this.files;
+
     // wrap in object so we can update template by reference if custom
     var aglioOptions = {
       template: options.theme
     };
-    
+
     // Make sure that the given theme exists
     aglio.getTemplates(function (err, names) {
       if(err){
@@ -36,28 +37,31 @@ module.exports = function(grunt) {
           aglioOptions.template = "default";
         }
       }
+      // Compile must happen after the template is verified in the callback
+      compile();
     });
 
-
-    this.files.forEach(function(f){
-      var concattedSrc = f.src.filter(function(path){
-        if(!grunt.file.exists(path)){
-          grunt.log.warn(path + " does not exist");
-          return false;
-        }else{
-          return true;
-        }
-      }).map(function(path){
-        return grunt.file.read(path);
-      }).join(options.seperator);
-      aglio.render(options.filter(concattedSrc), aglioOptions, function (err, html) {
-        if(err){
-          grunt.fail.fatal("Code:"+err.code+'\n'+"Message:"+err.message);
-        }
-        grunt.file.write(f.dest, html);
-        grunt.log.ok("Written to " + f.dest);
-        done();
+    var compile = function () {
+      files.forEach(function(f){
+        var concattedSrc = f.src.filter(function(path){
+          if(!grunt.file.exists(path)){
+            grunt.log.warn(path + " does not exist");
+            return false;
+          }else{
+            return true;
+          }
+        }).map(function(path){
+          return grunt.file.read(path);
+        }).join(options.seperator);
+        aglio.render(options.filter(concattedSrc), aglioOptions, function (err, html) {
+          if(err){
+            grunt.fail.fatal("Code:"+err.code+'\n'+"Message:"+err.message);
+          }
+          grunt.file.write(f.dest, html);
+          grunt.log.ok("Written to " + f.dest);
+          done();
+        });
       });
-    });
+    };
   });
 };

--- a/test/basicTest.js
+++ b/test/basicTest.js
@@ -77,6 +77,24 @@ describe('grunt aglio', function(){
 		}, 1000);
 	});
 
+  it('should use a custom jade template', function (done) {
+    var configObj = {};
+    configObj[output] = [path.resolve('./', 'test/sample.md')];
+    grunt.config('aglio.test.files', configObj);
+    grunt.config('aglio.test.theme', './node_modules/aglio/templates/slate');
+    grunt.task.run('aglio');
+    grunt.task.start();
+
+    setTimeout(function(){
+      fs.exists(output, function(exists){
+        assert(exists);
+        // Make sure that it used the slate theme
+        var contents = fs.readFileSync(output, 'utf8');
+        assert(contents.indexOf('//netdna.bootstrapcdn.com/bootswatch/3.1.1/slate/bootstrap.min.css') > -1);
+        resetTempFiles(done);
+      })
+    }, 1000);
+  });
 
 	after(function(done){
 		resetTempFiles(done);


### PR DESCRIPTION
In the current code, the getTemplates callback that verifies the template to use is not guaranteed to run running before the files.forEach loop.  this was confirmed by adding a small delay to the callback.

This change moves the call to run the compile stage to inside the getTemplates callback, ensuring that it will always run after custom template is resolved.

Note: If you merge the fix_spelling branch, you'll need to make sure that the references to `seperator` in this branch are updated to `separator`.
