### PR TITLE
Use Promises to ensure that every file is rendered before calling done()

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   ],
   "dependencies": {
     "aglio": "~1.15.0",
-    "underscore": "^1.7.0"
+    "underscore": "^1.7.0",
+    "when": "^3.4.4"
   }
 }

--- a/tasks/aglio.js
+++ b/tasks/aglio.js
@@ -1,18 +1,19 @@
 'use strict';
 
 var path = require('path');
+var when = require('when');
 
-module.exports = function(grunt) {
+module.exports = function (grunt) {
   var _ = require('underscore');
   var aglio = require('aglio');
-  grunt.registerMultiTask('aglio', 'Grunt plugin to generate aglio documentation', function() {
+  grunt.registerMultiTask('aglio', 'Grunt plugin to generate aglio documentation', function () {
     var done = this.async();
 
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
       separator: "",
       theme: "default",
-      filter: function(src){
+      filter: function (src) {
         return src;
       }
     });
@@ -26,14 +27,14 @@ module.exports = function(grunt) {
 
     // Make sure that the given theme exists
     aglio.getTemplates(function (err, names) {
-      if(err){
+      if (err) {
         grunt.log.warn(err);
       }
-      if(!_.contains(names, aglioOptions.template)){
+      if (!_.contains(names, aglioOptions.template)) {
         // Is a custom theme file presented
         aglioOptions.template = path.resolve(aglioOptions.template) + '.jade';
-        if(!grunt.file.exists(aglioOptions.template)) {
-          grunt.log.warn(aglioOptions.template+" theme does not exist, reverting to the default theme");
+        if (!grunt.file.exists(aglioOptions.template)) {
+          grunt.log.warn(aglioOptions.template + " theme does not exist, reverting to the default theme");
           aglioOptions.template = "default";
         }
       }
@@ -41,27 +42,33 @@ module.exports = function(grunt) {
       compile();
     });
 
-    var compile = function () {
-      files.forEach(function(f){
-        var concattedSrc = f.src.filter(function(path){
-          if(!grunt.file.exists(path)){
+    function compile() {
+      return when.all(when.map(files, function (f) {
+        var concattedSrc = f.src.filter(function (path) {
+          if (!grunt.file.exists(path)) {
             grunt.log.warn(path + " does not exist");
             return false;
-          }else{
+          } else {
             return true;
           }
-        }).map(function(path){
+        }).map(function (path) {
           return grunt.file.read(path);
         }).join(options.separator);
-        aglio.render(options.filter(concattedSrc), aglioOptions, function (err, html) {
-          if(err){
-            grunt.fail.fatal("Code:"+err.code+'\n'+"Message:"+err.message);
-          }
-          grunt.file.write(f.dest, html);
-          grunt.log.ok("Written to " + f.dest);
-          done();
+        return when.promise(function (resolve, reject) {
+          aglio.render(options.filter(concattedSrc), aglioOptions, function (err, html, warnings) {
+            if (typeof html == 'string') {
+              grunt.file.write(f.dest, html);
+              grunt.log.ok("Written to " + f.dest);
+              resolve(true);
+            } else {
+              reject({ error: err, warnings: warnings });
+            }
+          });
         });
-      });
-    };
+      })).then(done) // Don't call done until ALL the files have completed rendering
+        .catch(function (err) {
+          grunt.fail.fatal("Code:" + err.code + '\n' + "Message:" + err.err, err.warnings);
+        });
+    }
   });
 };

--- a/test/basicTest.js
+++ b/test/basicTest.js
@@ -15,7 +15,7 @@ describe('grunt aglio', function(){
 		// Get rid of the multiple md files
 		var filesToDelete = fs.readdirSync(path.resolve('./', 'test')).filter(function(filename){
 			var parts = filename.split('.');
-			return parts[parts.length - 1] === 'md' && parts[0] !== 'sample';
+			return (parts[parts.length - 1] === 'md' && parts[0] !== 'sample') || parts[parts.length - 1] === 'html';
 		});
 		for(var i = 0; i < filesToDelete.length; i++){
 			fs.unlinkSync(path.resolve('./', 'test/'+filesToDelete[i]));
@@ -96,7 +96,57 @@ describe('grunt aglio', function(){
     }, 1000);
   });
 
-	after(function(done){
+  it('should be able to create multiple output files', function(done){
+    // Split out sample.md into multiple small files
+    var sampleFile = fs.readFileSync(path.resolve('./', 'test/sample.md'), {
+      encoding: 'utf8'
+    }).split("\n");
+
+    var destFiles = [];
+    for(var i = 0; i < sampleFile.length; i++){
+      fs.writeFileSync(path.resolve('./', 'test/'+i+'.md'), sampleFile[i]);
+      destFiles.push(path.resolve('./', 'test/'+i+'.md'));
+    }
+
+    var configObj = {};
+    var configObj2 = {};
+    var configObj3 = {};
+    var configObj4 = {};
+    var configObj5 = {};
+    var output2 = output.substr(0, output.length - 4) + '2.html';
+    var output3 = output.substr(0, output.length - 4) + '3.html';
+    var output4 = output.substr(0, output.length - 4) + '4.html';
+    var output5 = output.substr(0, output.length - 4) + '5.html';
+    configObj[output2] = path.resolve('./', 'test/sample.md');
+    configObj[output] = destFiles;
+    configObj2[output2] = path.resolve('./', 'test/sample.md');
+    configObj3[output3] = path.resolve('./', 'test/sample.md');
+    configObj4[output4] = path.resolve('./', 'test/sample.md');
+    configObj5[output5] = path.resolve('./', 'test/sample.md');
+    grunt.config('aglio.test.files', configObj);
+    grunt.config('aglio.test.options.separator', grunt.util.linefeed);
+    grunt.config('aglio.test2.files', configObj2);
+    grunt.config('aglio.test2.options.separator', grunt.util.linefeed);
+    grunt.config('aglio.test3.files', configObj3);
+    grunt.config('aglio.test3.options.separator', grunt.util.linefeed);
+    grunt.config('aglio.test4.files', configObj4);
+    grunt.config('aglio.test4.options.separator', grunt.util.linefeed);
+    grunt.config('aglio.test5.files', configObj5);
+    grunt.config('aglio.test5.options.separator', grunt.util.linefeed);
+    grunt.task.run('aglio');
+    grunt.task.start();
+
+    setTimeout(function(){
+      assert(fs.existsSync(output));
+      assert(fs.existsSync(output2));
+      assert(fs.existsSync(output3));
+      assert(fs.existsSync(output4));
+      assert(fs.existsSync(output5));
+      resetTempFiles(done);
+    }, 4000);
+  });
+
+  after(function(done){
 		resetTempFiles(done);
 	})
 });


### PR DESCRIPTION
Grunt was existing as soon as done was called, which is currently in the aglio.render callback.  The problem is that the first file that completed the aglio build process would trigger done() and grunt would exit, even if there were other files being rendered.

This PR uses when.js promises to fix this problem.  It runs a mapper function against `this.files` that returns a `Promise` that resolves when `aglio.render` completes.  The array of Promises is passed to `when.all` which only resolves when all the promises in the array resolve.  `done()` is only called after when.all resolves all the promises.

I added a test to verify that the code works against a configuration with 5 separate configurations.
