### PR TITLE
Add support of `includePath` aglio option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Default value: `function(src) { return src; }`
 
 The src is passed through this function before passed into aglio. You can use this step to automatically add any tags, CI badges or build revision content into the src. Windows users can take advantage of this function to remove '\r' characters so that snowcrash will parse their files properly
 
+#### options.includePath
+Type: `String`
+Default value: `process.cwd()`
+
+Base directory for relative includes.
+
 ### Usage examples
 
 #### Basic

--- a/tasks/aglio.js
+++ b/tasks/aglio.js
@@ -22,7 +22,8 @@ module.exports = function (grunt) {
 
     // wrap in object so we can update template by reference if custom
     var aglioOptions = {
-      template: options.theme
+      template: options.theme,
+      includePath: options.includePath
     };
 
     // Make sure that the given theme exists

--- a/test/basicTest.js
+++ b/test/basicTest.js
@@ -146,6 +146,23 @@ describe('grunt aglio', function(){
     }, 4000);
   });
 
+  it('should be able to process include directive', function(done){
+    var configObj = {};
+    configObj[output] = [path.resolve('./', 'test/fixtures/sample-include.md')];
+    grunt.config('aglio.test.files', configObj);
+    grunt.config('aglio.test.options', {
+      includePath: path.join(__dirname, 'fixtures')
+    });
+
+    grunt.task.run('aglio');
+    grunt.task.start();
+
+    setTimeout(function(){
+      assert(fs.existsSync(output));
+      resetTempFiles(done);
+    }, 1000);
+  });
+
   after(function(done){
 		resetTempFiles(done);
 	})

--- a/test/fixtures/sample-include.md
+++ b/test/fixtures/sample-include.md
@@ -1,0 +1,7 @@
+FORMAT: 1A
+HOST: https://api.mywebsite.com
+
+# API Title
+[Markdown](http://daringfireball.net/projects/markdown/syntax) **formatted** description.
+
+<!-- include(sample-included.md) -->

--- a/test/fixtures/sample-included.md
+++ b/test/fixtures/sample-included.md
@@ -1,0 +1,17 @@
+
+## Subtitle
+Also Markdown *formatted*. This also includes automatic "smartypants" formatting -- hooray!
+
+> "A quote from another time and place"
+
+Another paragraph. Code sample:
+
+```http
+Authorization: bearer 5262d64b892e8d4341000001
+```
+
+And some code with no highlighting:
+
+```no-highlight
+Foo bar baz
+```


### PR DESCRIPTION
This option is useful for specify base path for relative include inside documents.